### PR TITLE
iOS Assignment Record/Save/Submit TableVCells

### DIFF
--- a/MusicMaker/MusicMaker.xcodeproj/project.pbxproj
+++ b/MusicMaker/MusicMaker.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		39CA2B592193901700C6018E /* MusicSheetPageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B582193901700C6018E /* MusicSheetPageCollectionViewCell.swift */; };
 		39CA2B5B219397DA00C6018E /* SamplePDF.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 39CA2B5A219397DA00C6018E /* SamplePDF.pdf */; };
 		39CA2B5D21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */; };
+		39CA2B5F2194AED500C6018E /* RecordButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */; };
 		BFD381BB219255540038F974 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BFD381BA219255540038F974 /* GoogleService-Info.plist */; };
 		BFD381C32193525F0038F974 /* Authentication.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD381C22193525F0038F974 /* Authentication.storyboard */; };
 		BFD381CC219354C70038F974 /* QRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD381CB219354C70038F974 /* QRScannerViewController.swift */; };
@@ -37,6 +38,7 @@
 		39CA2B582193901700C6018E /* MusicSheetPageCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MusicSheetPageCollectionViewCell.swift; sourceTree = "<group>"; };
 		39CA2B5A219397DA00C6018E /* SamplePDF.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = SamplePDF.pdf; sourceTree = "<group>"; };
 		39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentInstructionsTableViewCell.swift; sourceTree = "<group>"; };
+		39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordButtonTableViewCell.swift; sourceTree = "<group>"; };
 		BFD381BA219255540038F974 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BFD381C22193525F0038F974 /* Authentication.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Authentication.storyboard; sourceTree = "<group>"; };
 		BFD381CB219354C70038F974 /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				39CA2B5621938AA900C6018E /* AssignmentMusicPieceTableViewCell.swift */,
 				39CA2B582193901700C6018E /* MusicSheetPageCollectionViewCell.swift */,
 				39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */,
+				39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				399010C521925FC7004670BF /* UnsubmittedAssignmentViewController.swift in Sources */,
 				BFD3E55F2192393A00D84FF2 /* AppDelegate.swift in Sources */,
 				BFD381CE219355460038F974 /* SignUpViewController.swift in Sources */,
+				39CA2B5F2194AED500C6018E /* RecordButtonTableViewCell.swift in Sources */,
 				BFD381D0219355510038F974 /* LogInViewController.swift in Sources */,
 				BFD381CC219354C70038F974 /* QRScannerViewController.swift in Sources */,
 				39CA2B5D21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift in Sources */,

--- a/MusicMaker/MusicMaker.xcodeproj/project.pbxproj
+++ b/MusicMaker/MusicMaker.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		39CA2B5B219397DA00C6018E /* SamplePDF.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 39CA2B5A219397DA00C6018E /* SamplePDF.pdf */; };
 		39CA2B5D21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */; };
 		39CA2B5F2194AED500C6018E /* RecordButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */; };
+		39CA2B612194B2CA00C6018E /* AssignmentSaveSubmitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39CA2B602194B2CA00C6018E /* AssignmentSaveSubmitTableViewCell.swift */; };
 		BFD381BB219255540038F974 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BFD381BA219255540038F974 /* GoogleService-Info.plist */; };
 		BFD381C32193525F0038F974 /* Authentication.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD381C22193525F0038F974 /* Authentication.storyboard */; };
 		BFD381CC219354C70038F974 /* QRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD381CB219354C70038F974 /* QRScannerViewController.swift */; };
@@ -39,6 +40,7 @@
 		39CA2B5A219397DA00C6018E /* SamplePDF.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = SamplePDF.pdf; sourceTree = "<group>"; };
 		39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentInstructionsTableViewCell.swift; sourceTree = "<group>"; };
 		39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordButtonTableViewCell.swift; sourceTree = "<group>"; };
+		39CA2B602194B2CA00C6018E /* AssignmentSaveSubmitTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentSaveSubmitTableViewCell.swift; sourceTree = "<group>"; };
 		BFD381BA219255540038F974 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		BFD381C22193525F0038F974 /* Authentication.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Authentication.storyboard; sourceTree = "<group>"; };
 		BFD381CB219354C70038F974 /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 				39CA2B582193901700C6018E /* MusicSheetPageCollectionViewCell.swift */,
 				39CA2B5C21948D8C00C6018E /* AssignmentInstructionsTableViewCell.swift */,
 				39CA2B5E2194AED500C6018E /* RecordButtonTableViewCell.swift */,
+				39CA2B602194B2CA00C6018E /* AssignmentSaveSubmitTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -326,6 +329,7 @@
 			files = (
 				39CA2B5721938AA900C6018E /* AssignmentMusicPieceTableViewCell.swift in Sources */,
 				399010C521925FC7004670BF /* UnsubmittedAssignmentViewController.swift in Sources */,
+				39CA2B612194B2CA00C6018E /* AssignmentSaveSubmitTableViewCell.swift in Sources */,
 				BFD3E55F2192393A00D84FF2 /* AppDelegate.swift in Sources */,
 				BFD381CE219355460038F974 /* SignUpViewController.swift in Sources */,
 				39CA2B5F2194AED500C6018E /* RecordButtonTableViewCell.swift in Sources */,

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -370,6 +370,9 @@
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                             <state key="normal" title="Tap To Record" image="RecordIcon"/>
+                                            <connections>
+                                                <action selector="recordButtonTapped:" destination="hal-Rq-1Ak" eventType="touchUpInside" id="avm-6Z-eHt"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -377,6 +380,9 @@
                                         <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerY" secondItem="43K-dp-uDy" secondAttribute="centerY" id="dpu-9a-SAS"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="recordButton" destination="Hgb-qT-0lm" id="ymV-sT-eYR"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -12,7 +12,7 @@
         <scene sceneID="eoW-vP-84y">
             <objects>
                 <tableViewController id="3n0-iy-li9" customClass="UnsubmittedAssignmentViewController" customModule="MusicMaker" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="6CS-05-EvE">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="6CS-05-EvE">
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="28" width="768" height="219"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qGe-SX-Gia" id="Nob-jp-yDG">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="218.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="219"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MusicLines" translatesAutoresizingMaskIntoConstraints="NO" id="lhe-B1-Nw1">
@@ -245,7 +245,7 @@
                                 <rect key="frame" x="0.0" y="247" width="768" height="258"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LL9-J6-nHu" id="NGR-oW-vyv">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="257.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="258"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Piece: Waltz from Sleeping Beauty" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="41G-wQ-nSC">
@@ -317,7 +317,7 @@
                                 <rect key="frame" x="0.0" y="505" width="768" height="172"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cIG-0w-tq2" id="OL0-yp-Vuy">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="171.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="172"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Instructions" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I34-B2-X7v">
@@ -359,7 +359,7 @@
                                 <rect key="frame" x="0.0" y="677" width="768" height="78"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hal-Rq-1Ak" id="43K-dp-uDy">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="77.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="78"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hgb-qT-0lm">
@@ -391,7 +391,7 @@
                                 <rect key="frame" x="0.0" y="755" width="768" height="81"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="80.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="81"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2k-yD-eYg">

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -363,14 +363,15 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hgb-qT-0lm">
-                                            <rect key="frame" x="288" y="5.5" width="192" height="50"/>
+                                            <rect key="frame" x="234" y="5.5" width="300" height="50"/>
                                             <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="Wed-02-qw7"/>
+                                                <constraint firstAttribute="width" constant="300" id="mGG-5a-dF6"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                             <state key="normal" title="Tap To Record" image="RecordIcon">
-                                                <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                             </state>
                                             <connections>
                                                 <action selector="recordButtonTapped:" destination="hal-Rq-1Ak" eventType="touchUpInside" id="avm-6Z-eHt"/>
@@ -389,15 +390,28 @@
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="81" id="EY2-oo-8W9">
                                 <rect key="frame" x="0.0" y="738" width="768" height="81"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
                                     <rect key="frame" x="0.0" y="0.0" width="768" height="81"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2k-yD-eYg">
-                                            <rect key="frame" x="288" y="15" width="192" height="50"/>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2k-yD-eYg">
+                                            <rect key="frame" x="120" y="15.5" width="192" height="50"/>
                                             <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
+                                                <constraint firstAttribute="width" constant="192" id="sui-u0-odJ"/>
                                                 <constraint firstAttribute="height" constant="50" id="yex-8N-pjf"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                            <state key="normal" title="Save">
+                                                <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            </state>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cgn-wz-yJI">
+                                            <rect key="frame" x="457" y="15.5" width="192" height="50"/>
+                                            <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="192" id="8dg-Ki-KgU"/>
+                                                <constraint firstAttribute="height" constant="50" id="dfe-rF-m5E"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                             <state key="normal" title="Submit">
@@ -405,6 +419,13 @@
                                             </state>
                                         </button>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="cgn-wz-yJI" firstAttribute="centerY" secondItem="CDR-dh-F3I" secondAttribute="centerY" id="NQE-cW-7aX"/>
+                                        <constraint firstItem="G2k-yD-eYg" firstAttribute="leading" secondItem="CDR-dh-F3I" secondAttribute="leading" constant="120" id="R1e-Hy-i6u"/>
+                                        <constraint firstItem="G2k-yD-eYg" firstAttribute="centerY" secondItem="CDR-dh-F3I" secondAttribute="centerY" id="Z8m-xk-Rj3"/>
+                                        <constraint firstAttribute="trailing" secondItem="cgn-wz-yJI" secondAttribute="trailing" constant="120" id="df6-ir-00L"/>
+                                        <constraint firstItem="cgn-wz-yJI" firstAttribute="leading" secondItem="G2k-yD-eYg" secondAttribute="trailing" constant="145" id="gei-SY-vpv"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -12,7 +12,7 @@
         <scene sceneID="eoW-vP-84y">
             <objects>
                 <tableViewController id="3n0-iy-li9" customClass="UnsubmittedAssignmentViewController" customModule="MusicMaker" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="6CS-05-EvE">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="6CS-05-EvE">
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="28" width="768" height="219"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qGe-SX-Gia" id="Nob-jp-yDG">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="219"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="218.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MusicLines" translatesAutoresizingMaskIntoConstraints="NO" id="lhe-B1-Nw1">
@@ -245,7 +245,7 @@
                                 <rect key="frame" x="0.0" y="247" width="768" height="258"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LL9-J6-nHu" id="NGR-oW-vyv">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="258"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="257.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Music Piece: Waltz from Sleeping Beauty" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="41G-wQ-nSC">
@@ -317,7 +317,7 @@
                                 <rect key="frame" x="0.0" y="505" width="768" height="172"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cIG-0w-tq2" id="OL0-yp-Vuy">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="172"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="171.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Instructions" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I34-B2-X7v">
@@ -355,21 +355,20 @@
                                     <outlet property="teacherLabel" destination="wdC-rr-T5R" id="JH6-Ld-zmg"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecordButtonCell" rowHeight="61" id="hal-Rq-1Ak" customClass="RecordButtonTableViewCell" customModule="MusicMaker" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="677" width="768" height="61"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecordButtonCell" rowHeight="78" id="hal-Rq-1Ak" customClass="RecordButtonTableViewCell" customModule="MusicMaker" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="677" width="768" height="78"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hal-Rq-1Ak" id="43K-dp-uDy">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="61"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hal-Rq-1Ak" id="43K-dp-uDy">
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="77.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hgb-qT-0lm">
-                                            <rect key="frame" x="234" y="5.5" width="300" height="50"/>
+                                            <rect key="frame" x="234" y="10" width="300" height="50"/>
                                             <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="50" id="Wed-02-qw7"/>
                                                 <constraint firstAttribute="width" constant="300" id="mGG-5a-dF6"/>
                                             </constraints>
-                                            <fontDescription key="fontDescription" type="system" pointSize="25"/>
                                             <state key="normal" title="Tap To Record" image="RecordIcon">
                                                 <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                             </state>
@@ -379,23 +378,24 @@
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerX" secondItem="43K-dp-uDy" secondAttribute="centerX" id="Eai-4r-OdX"/>
-                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerY" secondItem="43K-dp-uDy" secondAttribute="centerY" id="dpu-9a-SAS"/>
+                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerX" secondItem="43K-dp-uDy" secondAttribute="centerX" id="LsZ-WT-M4y"/>
+                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="top" secondItem="43K-dp-uDy" secondAttribute="top" constant="10" id="c8P-sm-Fyj"/>
+                                        <constraint firstAttribute="bottom" secondItem="Hgb-qT-0lm" secondAttribute="bottom" constant="10" id="kI4-cd-4V0"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="recordButton" destination="Hgb-qT-0lm" id="ymV-sT-eYR"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="81" id="EY2-oo-8W9">
-                                <rect key="frame" x="0.0" y="738" width="768" height="81"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SaveSubmitCell" rowHeight="81" id="EY2-oo-8W9" customClass="AssignmentSaveSubmitTableViewCell" customModule="MusicMaker" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="755" width="768" height="81"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="81"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="80.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2k-yD-eYg">
-                                            <rect key="frame" x="120" y="15.5" width="192" height="50"/>
+                                            <rect key="frame" x="120" y="21.5" width="192" height="50"/>
                                             <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="192" id="sui-u0-odJ"/>
@@ -405,9 +405,12 @@
                                             <state key="normal" title="Save">
                                                 <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                             </state>
+                                            <connections>
+                                                <action selector="saveButtonTapped:" destination="EY2-oo-8W9" eventType="touchUpInside" id="biS-1G-uDf"/>
+                                            </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cgn-wz-yJI">
-                                            <rect key="frame" x="457" y="15.5" width="192" height="50"/>
+                                            <rect key="frame" x="457" y="21.5" width="192" height="50"/>
                                             <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="192" id="8dg-Ki-KgU"/>
@@ -417,16 +420,25 @@
                                             <state key="normal" title="Submit">
                                                 <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
                                             </state>
+                                            <connections>
+                                                <action selector="submitButtonTapped:" destination="EY2-oo-8W9" eventType="touchUpInside" id="msv-sZ-gR2"/>
+                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="cgn-wz-yJI" firstAttribute="centerY" secondItem="CDR-dh-F3I" secondAttribute="centerY" id="NQE-cW-7aX"/>
+                                        <constraint firstItem="G2k-yD-eYg" firstAttribute="top" secondItem="CDR-dh-F3I" secondAttribute="topMargin" constant="10" id="4Lb-dc-9PT"/>
+                                        <constraint firstAttribute="bottom" secondItem="cgn-wz-yJI" secondAttribute="bottom" constant="10" id="7rg-m8-lHq"/>
                                         <constraint firstItem="G2k-yD-eYg" firstAttribute="leading" secondItem="CDR-dh-F3I" secondAttribute="leading" constant="120" id="R1e-Hy-i6u"/>
-                                        <constraint firstItem="G2k-yD-eYg" firstAttribute="centerY" secondItem="CDR-dh-F3I" secondAttribute="centerY" id="Z8m-xk-Rj3"/>
+                                        <constraint firstAttribute="bottom" secondItem="G2k-yD-eYg" secondAttribute="bottom" constant="10" id="SIx-ba-q6S"/>
                                         <constraint firstAttribute="trailing" secondItem="cgn-wz-yJI" secondAttribute="trailing" constant="120" id="df6-ir-00L"/>
                                         <constraint firstItem="cgn-wz-yJI" firstAttribute="leading" secondItem="G2k-yD-eYg" secondAttribute="trailing" constant="145" id="gei-SY-vpv"/>
+                                        <constraint firstItem="cgn-wz-yJI" firstAttribute="top" secondItem="CDR-dh-F3I" secondAttribute="topMargin" constant="10" id="yXR-cq-nDg"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="saveButton" destination="G2k-yD-eYg" id="i2A-9j-qka"/>
+                                    <outlet property="submitButton" destination="cgn-wz-yJI" id="iDY-pc-FHr"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -369,7 +369,9 @@
                                                 <constraint firstAttribute="height" constant="50" id="Wed-02-qw7"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                            <state key="normal" title="Tap To Record" image="RecordIcon"/>
+                                            <state key="normal" title="Tap To Record" image="RecordIcon">
+                                                <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
                                             <connections>
                                                 <action selector="recordButtonTapped:" destination="hal-Rq-1Ak" eventType="touchUpInside" id="avm-6Z-eHt"/>
                                             </connections>
@@ -383,6 +385,27 @@
                                 <connections>
                                     <outlet property="recordButton" destination="Hgb-qT-0lm" id="ymV-sT-eYR"/>
                                 </connections>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="81" id="EY2-oo-8W9">
+                                <rect key="frame" x="0.0" y="738" width="768" height="81"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EY2-oo-8W9" id="CDR-dh-F3I">
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="81"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G2k-yD-eYg">
+                                            <rect key="frame" x="288" y="15" width="192" height="50"/>
+                                            <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="50" id="yex-8N-pjf"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                            <state key="normal" title="Submit">
+                                                <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            </state>
+                                        </button>
+                                    </subviews>
+                                </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
+++ b/MusicMaker/MusicMaker/Storyboards/UnsubmittedAssignmentViewController.storyboard
@@ -355,6 +355,29 @@
                                     <outlet property="teacherLabel" destination="wdC-rr-T5R" id="JH6-Ld-zmg"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="RecordButtonCell" rowHeight="61" id="hal-Rq-1Ak" customClass="RecordButtonTableViewCell" customModule="MusicMaker" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="677" width="768" height="61"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hal-Rq-1Ak" id="43K-dp-uDy">
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="61"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Hgb-qT-0lm">
+                                            <rect key="frame" x="288" y="5.5" width="192" height="50"/>
+                                            <color key="backgroundColor" red="0.6429060767" green="0.74506644749999995" blue="0.88638166240000005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="50" id="Wed-02-qw7"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                            <state key="normal" title="Tap To Record" image="RecordIcon"/>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerX" secondItem="43K-dp-uDy" secondAttribute="centerX" id="Eai-4r-OdX"/>
+                                        <constraint firstItem="Hgb-qT-0lm" firstAttribute="centerY" secondItem="43K-dp-uDy" secondAttribute="centerY" id="dpu-9a-SAS"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
                         </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="3n0-iy-li9" id="5q4-ej-dBf"/>
@@ -369,6 +392,7 @@
     </scenes>
     <resources>
         <image name="MusicLines" width="18" height="140"/>
+        <image name="RecordIcon" width="40" height="40"/>
         <image name="TrebleSymbol" width="70" height="140"/>
     </resources>
 </document>

--- a/MusicMaker/MusicMaker/View Controllers/UnsubmittedAssignmentViewController.swift
+++ b/MusicMaker/MusicMaker/View Controllers/UnsubmittedAssignmentViewController.swift
@@ -20,7 +20,7 @@ class UnsubmittedAssignmentViewController: UITableViewController {
     // MARK: - UITableViewDataSource
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        return 4
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -51,6 +51,10 @@ class UnsubmittedAssignmentViewController: UITableViewController {
             
             cell.instructions = "This instruction is just a test because I want to see how long this will go on for, but I really don't know until I start testing it. This could take some times as I think of something to type here. This is stil not long enough so I'm going to make up some more stuff. Maybe this should be good now?"
             cell.teacher = "Mrs. Mozart"
+            
+            return cell
+        case 3:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "RecordButtonCell", for: indexPath) as! RecordButtonTableViewCell
             
             return cell
         default:

--- a/MusicMaker/MusicMaker/View Controllers/UnsubmittedAssignmentViewController.swift
+++ b/MusicMaker/MusicMaker/View Controllers/UnsubmittedAssignmentViewController.swift
@@ -20,7 +20,7 @@ class UnsubmittedAssignmentViewController: UITableViewController {
     // MARK: - UITableViewDataSource
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 4
+        return 5
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -56,6 +56,11 @@ class UnsubmittedAssignmentViewController: UITableViewController {
         case 3:
             let cell = tableView.dequeueReusableCell(withIdentifier: "RecordButtonCell", for: indexPath) as! RecordButtonTableViewCell
             
+            return cell
+        case 4:
+            let cell = tableView.dequeueReusableCell(withIdentifier: "SaveSubmitCell", for: indexPath) as! AssignmentSaveSubmitTableViewCell
+            
+//            cell.delegate = self
             return cell
         default:
             fatalError("We forgot a case: \(indexPath.row)")

--- a/MusicMaker/MusicMaker/Views/AssignmentSaveSubmitTableViewCell.swift
+++ b/MusicMaker/MusicMaker/Views/AssignmentSaveSubmitTableViewCell.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+// need delegate
+
 class AssignmentSaveSubmitTableViewCell: UITableViewCell {
     
     // MARK: - Outlets/Actions
@@ -27,7 +29,10 @@ class AssignmentSaveSubmitTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        
+        saveButton.layer.cornerRadius = 5
+        saveButton.clipsToBounds = true
+        submitButton.layer.cornerRadius = 5
+        submitButton.clipsToBounds = true
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MusicMaker/MusicMaker/Views/AssignmentSaveSubmitTableViewCell.swift
+++ b/MusicMaker/MusicMaker/Views/AssignmentSaveSubmitTableViewCell.swift
@@ -1,0 +1,39 @@
+//
+//  AssignmentSubmitTableViewCell.swift
+//  MusicMaker
+//
+//  Created by Linh Bouniol on 11/8/18.
+//  Copyright © 2018 Vuk. All rights reserved.
+//
+
+import UIKit
+
+class AssignmentSaveSubmitTableViewCell: UITableViewCell {
+    
+    // MARK: - Outlets/Actions
+    
+    @IBOutlet weak var saveButton: UIButton!
+    @IBOutlet weak var submitButton: UIButton!
+    
+    @IBAction func saveButtonTapped(_ sender: Any) {
+        // save locally
+    }
+    
+    @IBAction func submitButtonTapped(_ sender: Any) {
+        // post to firebase
+        // get notification if submitting is successful
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/MusicMaker/MusicMaker/Views/RecordButtonTableViewCell.swift
+++ b/MusicMaker/MusicMaker/Views/RecordButtonTableViewCell.swift
@@ -21,7 +21,9 @@ class RecordButtonTableViewCell: UITableViewCell {
     override func awakeFromNib() {  // This will never be called if the cell is created in code.
         super.awakeFromNib()
         
-        recordButton.layer.cornerRadius = 2
+        recordButton.layer.cornerRadius = 5
+        recordButton.clipsToBounds = true
+//        recordButton.layer.borderWidth = 1
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/MusicMaker/MusicMaker/Views/RecordButtonTableViewCell.swift
+++ b/MusicMaker/MusicMaker/Views/RecordButtonTableViewCell.swift
@@ -1,0 +1,33 @@
+//
+//  RecordButtonTableViewCell.swift
+//  MusicMaker
+//
+//  Created by Linh Bouniol on 11/8/18.
+//  Copyright © 2018 Vuk. All rights reserved.
+//
+
+import UIKit
+
+class RecordButtonTableViewCell: UITableViewCell {
+    
+    // MARK: - Outlets/Actions
+    
+    @IBOutlet weak var recordButton: UIButton!
+    
+    @IBAction func recordButtonTapped(_ sender: Any) {
+        // present the recording screen
+    }
+    
+    override func awakeFromNib() {  // This will never be called if the cell is created in code.
+        super.awakeFromNib()
+        
+        recordButton.layer.cornerRadius = 2
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}


### PR DESCRIPTION
# Description

I added some buttons to the table view that allows the user to tap when they want to record, save, or submit the assignment. Currently the buttons are not hooked up because the recording screen and Firestore still need to be set up.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts